### PR TITLE
Fixing a non-cygwin process deadlock situation

### DIFF
--- a/winsup/cygwin/spawn.cc
+++ b/winsup/cygwin/spawn.cc
@@ -848,9 +848,7 @@ loop:
   if ((mode == _P_DETACH || mode == _P_NOWAIT) && !iscygwin ())
     synced = false;
   else
-    /* Just mark a non-cygwin process as 'synced'.  We will still eventually
-       wait for it to exit in maybe_set_exit_code_from_windows(). */
-    synced = iscygwin () ? sync (pi.dwProcessId, pi.hProcess, INFINITE) : true;
+    synced = sync (pi.dwProcessId, pi.hProcess, INFINITE);
 
   switch (mode)
     {


### PR DESCRIPTION
#### References
##### Reported at

http://sourceware.org/bugzilla/show_bug.cgi?id=14580
##### Related commit

33b1b2c
http://cygwin.com/snapshots/winsup-changelog-20120504-20120507
http://cygwin.com/ml/cygwin-cvs/2012-q2/msg00066.html
##### Related discussion

http://cygwin.com/ml/cygwin/2012-05/threads.html#00349
#### Additional notes

If not waiting in sync waiting is instead done in wait_for_myself or myself.exit.
#### Reproduce

the program hangs at `pgrep bash 2`

```
apt-cyg install mingw64-i686-gcc-g++ make
curl -s http://pastebin.com/raw.php?i=tU50RaWZ>readm.cpp && curl -s http://pastebin.com/raw.php?i=vtY3eNRG|dos2unix>deadlock.test.sh && i686-w64-mingw32-g++ -static-libgcc -static-libstdc++ readm.cpp -o readm && ./deadlock.test.sh
```

example of code that hangs

```
pid_t pn2pid(string pn_s) {
    ...
    // reading /proc/#/cmdline hangs at 'ifstream f(...)'
    // return pid_t(atoi(shell("pidof %s", pn_s.c_str()).c_str()));
    // return pid_t(atoi(shell("pgrep -n %s", pn_s.c_str()).c_str()));
    // return pid_t(atoi(shell("procps|grep %s|head -1|awk '{print $1}'", pn_s.c_str()).c_str()));
}
```

code that doesn't hang

```
// return pid_t(atoi(shell("ps -s|grep %s|head -1|awk '{print $1}'", pn_s.c_str()).c_str()));
```
#### Request

If commiting in cvs please give me authorship credit by setting me as commit author

```
sudo useradd johnpeterson -gcvsusr -p $(printf "jp"|makepasswd --clearfrom=- --crypt-md5|awk '{print $2}')  # add cvsusr
curl -s https://github.com/john-peterson/cygwin/commit/4d59e40a8aff6127eca63b74e60462f6dc94aa82.patch|patch -p0 # apply patch
cvs -d:ext:johnpeterson@cygwin.com:/cvs/src ci -m "Fixing a non-cygwin process deadlock situation by waiting for a spawned process with WaitForMultipleObjects (process and child, as was previously done) instead of WaitForSingleObject." # commit
```
